### PR TITLE
Make second argument key non-optional on map/filter

### DIFF
--- a/src/HashMap/filter.ts
+++ b/src/HashMap/filter.ts
@@ -19,5 +19,5 @@ export const filter: FilterFn = function filter<K, V>(
 };
 
 export interface FilterFn {
-  <K, V>(predicate: (value: V, key?: K) => boolean, hashmap: HashMap<K, V>): HashMap<K, V>;
+  <K, V>(predicate: (value: V, key: K) => boolean, hashmap: HashMap<K, V>): HashMap<K, V>;
 }

--- a/src/HashMap/forEach.ts
+++ b/src/HashMap/forEach.ts
@@ -2,7 +2,7 @@ import { HashMap } from './HashMap';
 import { reduce } from './reduce';
 
 export const forEach: ForEachFn = function forEach<K, V>(
-  f: (value: V, key?: K) => any,
+  f: (value: V, key: K) => any,
   map: HashMap<K, V>): HashMap<K, V>
 {
   reduce((_, value, key) => f(value, key), null, map);
@@ -11,5 +11,5 @@ export const forEach: ForEachFn = function forEach<K, V>(
 };
 
 export interface ForEachFn {
-  <K, V>(f: (value: V, key?: K) => any, hashmap: HashMap<K, V>): HashMap<K, V>;
+  <K, V>(f: (value: V, key: K) => any, hashmap: HashMap<K, V>): HashMap<K, V>;
 }

--- a/src/HashMap/map.ts
+++ b/src/HashMap/map.ts
@@ -4,7 +4,7 @@ import { reduce } from './reduce';
 import { set } from './set';
 
 export const map: MapFn = function map<K, V, R>(
-  f: (value: V, key?: K) => R,
+  f: (value: V, key: K) => R,
   hashmap: HashMap<K, V>): HashMap<K, R>
 {
   return reduce(
@@ -17,5 +17,5 @@ export const map: MapFn = function map<K, V, R>(
 };
 
 export interface MapFn {
-  <K, V, R>(f: (value: V, key?: K) => R, map: HashMap<K, V>): HashMap<K, R>;
+  <K, V, R>(f: (value: V, key: K) => R, map: HashMap<K, V>): HashMap<K, R>;
 }


### PR DESCRIPTION
Issues/Discussion are disabled, so here's a question in the shape of a PR: why do filter/map functions have signature `(value: V, key?: K)` instead of `(value: V, key: K)`?  With that signature, `key` has type `K | undefined`, which is unhelpful for the caller of these two functions.